### PR TITLE
Front 82 - 🛂 Persist user data on authentication

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,7 @@ const nextConfig = {
             'res.cloudinary.com',
             'api.multiavatar.com',
             'cdn.pixabay.com',
+            'img.clerk.com',
         ],
     },
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import Navbar from '@/components/designSystem/navbar'
 
 import { pagePaths } from '@/utils/constants'
 import ReactQueryProvider from '@/utils/providers/ReactQuery'
+import UserStoreProvider from '@/utils/providers/UserStoreProvider'
 
 import './globals.css'
 import { ClerkProvider } from '@clerk/nextjs'
@@ -69,6 +70,7 @@ const Layout = ({
                         <Navbar />
                     </header>
                     <main className='flex-grow'>
+                        <UserStoreProvider />
                         <Toaster />
                         {children}
                     </main>

--- a/src/components/forms/userRegistration.tsx
+++ b/src/components/forms/userRegistration.tsx
@@ -169,7 +169,7 @@ export const RegistrationForm = (): React.JSX.Element => {
                     setUserData({
                         pseudo,
                         avatarUrl,
-                        ...(addressObject && { address: [addressObject] }),
+                        isPremium: false,
                     })
 
                     router.push(`${pagePaths.HOME}?onboardingSuccess=true`)

--- a/src/components/userActions/InstantTransactionRequest/index.tsx
+++ b/src/components/userActions/InstantTransactionRequest/index.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { Button } from '@/components/shadcn/ui/button'
+
+import { useSendEmail } from '@/utils/apiCalls/local/mutations'
+import { userMessages } from '@/utils/constants'
+import { notify } from '@/utils/functions/toasterHelper'
+
+import { NotificationType } from '@/types'
+import type { Article } from '@/types/article'
+
+const InstantTransactionRequest = ({
+    userB,
+    articleB,
+}: {
+    readonly senderEmail: string | undefined
+    readonly receiverEmail: string | undefined
+    readonly article: Partial<Article>
+}): React.JSX.Element => {
+    const { mutateAsync: sendEmail, isSuccess: emailSent } = useSendEmail()
+
+    // TODO : Get userA from useUser store
+
+    const handleSendEmail = async (): Promise<void> => {
+        if (!userA || !userB || !articleB) {
+            notify({
+                message: userMessages.requestSent.type.ERROR,
+                type: NotificationType.enum.ERROR,
+            })
+            return
+        }
+
+        await sendEmail(
+            {
+                userA,
+                userB,
+                articleB,
+            },
+
+            {
+                onSuccess: () => {
+                    notify({
+                        message: userMessages.requestSent.type.SUCCESS,
+                        type: NotificationType.enum.SUCCESS,
+                    })
+                },
+                onError: () => {
+                    notify({
+                        message: userMessages.requestSent.type.ERROR,
+                        type: NotificationType.enum.ERROR,
+                    })
+                },
+            },
+        )
+    }
+
+    return (
+        <div>
+            <Button
+                disabled={emailSent}
+                onClick={() => {
+                    handleSendEmail()
+                }}
+                className='bg-teal-500 text-white'
+                aria-label='Je veux acheter cet article'
+            >
+                {emailSent ? 'Demande envoyée !' : 'Je veux !'}
+            </Button>
+        </div>
+    )
+}
+
+export default InstantTransactionRequest

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -5,46 +5,54 @@ import { immer } from 'zustand/middleware/immer'
 import type { User } from '@/types/user'
 
 type UserStore = {
-    user: User
+    user: Partial<User>
     setUserData: (userData: Partial<User>) => void
+    resetUserData: () => void
 }
 
 /**
- * This store is used to manage user data, including pseudo, avatarUrl, isPremium status, and address.
+ * This store is used to manage non-sensitive user data.
  * It provides a method to update the user data partially.
  */
 export const useUserStore = create<UserStore>()(
     persist(
         immer((set) => ({
             user: {
-                id: '',
-                version: 0,
                 pseudo: '',
-                name: '',
-                surname: '',
-                email: '',
-                phoneNumber: undefined,
-                activityStatus: {
-                    lastConnected: new Date(),
-                    birthday: new Date(),
-                },
-                birthDate: new Date(),
-                avatarUrl: undefined,
+                avatarUrl: '',
                 isPremium: false,
-                credit: undefined,
-                articles: undefined,
-                debit: undefined,
+                credit: 0,
+                balance: 0,
+                articles: [],
+                comments: [],
+                favoriteArticles: [],
             },
 
+            /**
+             * This function updates the user data partially.
+             * @param {Partial<User>} userData - The user data to update.
+             */
             setUserData: (userData: Partial<User>): void => {
-                set((state) => {
+                set((state: UserStore) => {
                     state.user = { ...state.user, ...userData }
                 })
             },
 
-            deleteStoredUserData: (): void => {
-                set((state) => {
-                    state.user = {} as User
+            /**
+             * This function deletes the user data, to be used when the user logs out.
+             */
+            resetUserData: (): void => {
+                set((state: UserStore) => {
+                    state.user = {
+                        pseudo: '',
+                        avatarUrl: '',
+                        isPremium: false,
+                        credit: 0,
+                        balance: 0,
+                        articles: [],
+                        comments: [],
+                        favoriteArticles: [],
+                    }
                 })
             },
         })),

--- a/src/types/user/index.ts
+++ b/src/types/user/index.ts
@@ -4,11 +4,6 @@ import { z } from 'zod'
 
 import { AddressSchema } from '@/types/address/userAddress'
 
-const BankInfoSchema = z.object({
-    IBAN: z.string(),
-    BIC: z.string(),
-})
-
 export const ActivityStatusSchema = z.object({
     lastConnected: z.date(),
     birthday: z.date(),
@@ -16,7 +11,6 @@ export const ActivityStatusSchema = z.object({
 
 export const UserSchema = z.object({
     id: z.string(),
-    version: z.number().int(),
     pseudo: z.string(),
     name: z.string(),
     surname: z.string(),
@@ -26,14 +20,13 @@ export const UserSchema = z.object({
     phoneNumber: z.string().optional(),
     activityStatus: ActivityStatusSchema,
     birthDate: z.date(),
-    bankInfo: BankInfoSchema.optional(),
     avatarUrl: z.string().url().optional(),
     isPremium: z.boolean(),
     favoriteArticles: z.array(z.string()).optional(),
-    credit: z.number().int().optional(),
+    credit: z.number().optional(),
+    balance: z.number().optional(),
     comments: z.array(z.string()).optional(),
     articles: z.array(z.string()).optional(),
-    debit: z.array(z.string()).optional(),
 })
 
 export type User = z.infer<typeof UserSchema>

--- a/src/utils/apiCalls/user/index.ts
+++ b/src/utils/apiCalls/user/index.ts
@@ -76,13 +76,17 @@ export const createUser = async (
  * @returns {Promise<User>|undefined} A promise that resolves with user information.
  */
 export const getUserById = async (
-    userId: string | undefined,
+    userId: string | undefined | null,
 ): Promise<User | undefined> => {
+    if (!userId) return undefined
+
     const response: AxiosResponse<User> = await userInstance.get(
         `${apiEndpoints.microServices.public.USERS}${userId}`,
     )
+
     if (response.status !== 200)
         throw new Error(`Failed to fetch user with id ${String(userId)}`)
+
     return response.data
 }
 

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -4,6 +4,7 @@ export const paginationLimit = 20
 /** The list of React Query keys  */
 export const rqKeys = {
     USERS: 'users',
+    USER: 'user',
 }
 
 /** Object containing page paths used throughout the application, set in alphabetical order */

--- a/src/utils/providers/UserStoreProvider.tsx
+++ b/src/utils/providers/UserStoreProvider.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import { useUserStore } from '@/stores/user'
+
+import { getUserById } from '../apiCalls/user'
+import { rqKeys } from '../constants'
+import { useAuth } from '@clerk/nextjs'
+import { useQuery } from '@tanstack/react-query'
+
+const UserStoreProvider = (): undefined => {
+    const { isLoaded, userId, isSignedIn } = useAuth()
+
+    const setUserData = useUserStore((state) => state.setUserData)
+    const resetUserData = useUserStore((state) => state.resetUserData)
+    const userStore = useUserStore((state) => state.user)
+
+    const { data: userQuery } = useQuery({
+        queryKey: [rqKeys.USER, userId],
+        queryFn: () => getUserById(userId),
+        enabled: !!userId,
+    })
+
+    useEffect(() => {
+        if (isLoaded && isSignedIn && userQuery && !userStore.pseudo) {
+            setUserData({
+                id: userId,
+                pseudo: userQuery.pseudo,
+                avatarUrl: userQuery.avatarUrl,
+                credit: userQuery.credit,
+                balance: userQuery.balance,
+                isPremium: userQuery.isPremium,
+            })
+        }
+
+        if (!isSignedIn && userStore.pseudo) resetUserData()
+    }, [
+        isLoaded,
+        isSignedIn,
+        userId,
+        setUserData,
+        userQuery,
+        userStore,
+        resetUserData,
+    ])
+
+    return undefined
+}
+
+export default UserStoreProvider


### PR DESCRIPTION
Modif sur ce ticket: 
- Update sur le Schema du user
- Ajout d'un provider qui ajoute des données *non-sensitive* du user dans le store au moment du log in
- Au moment de la déconnexion, on reset le user store

Avantage du ticket est d'avoir des petites metadata du user, comme le pseudo, l'avatar, le isPremium boolean...à tout moment sans avoir à faire une requête au micro-service pour ça.