### PR TITLE
🛂 Persist user data on authentication

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,7 @@ const nextConfig = {
             'res.cloudinary.com',
             'api.multiavatar.com',
             'cdn.pixabay.com',
+            'img.clerk.com',
         ],
     },
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import Navbar from '@/components/designSystem/navbar'
 
 import { pagePaths } from '@/utils/constants'
 import ReactQueryProvider from '@/utils/providers/ReactQuery'
+import UserStoreProvider from '@/utils/providers/UserStoreProvider'
 
 import './globals.css'
 import { ClerkProvider } from '@clerk/nextjs'
@@ -69,6 +70,7 @@ const Layout = ({
                         <Navbar />
                     </header>
                     <main className='flex-grow'>
+                        <UserStoreProvider />
                         <Toaster />
                         {children}
                     </main>

--- a/src/components/forms/userRegistration.tsx
+++ b/src/components/forms/userRegistration.tsx
@@ -169,7 +169,6 @@ export const RegistrationForm = (): React.JSX.Element => {
                     setUserData({
                         pseudo,
                         avatarUrl,
-                        ...(addressObject && { address: [addressObject] }),
                     })
 
                     router.push(`${pagePaths.HOME}?onboardingSuccess=true`)

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -49,9 +49,12 @@ export const useUserStore = create<UserStore>()(
         })),
         {
             name: 'user-store',
-            onRehydrateStorage: () => (state) => {
-                state?.setHasHydrated(true)
-            },
+            onRehydrateStorage:
+                () =>
+                // eslint-disable-next-line unicorn/consistent-function-scoping
+                (state: UserStore | undefined): void => {
+                    state?.setHasHydrated(true)
+                },
         },
     ),
 )

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -5,8 +5,9 @@ import { immer } from 'zustand/middleware/immer'
 import type { User } from '@/types/user'
 
 type UserStore = {
-    user: User
+    user: Partial<User>
     setUserData: (userData: Partial<User>) => void
+    resetUserData: () => void
 }
 
 /**
@@ -17,23 +18,14 @@ export const useUserStore = create<UserStore>()(
     persist(
         immer((set) => ({
             user: {
-                id: '',
-                version: 0,
                 pseudo: '',
-                name: '',
-                surname: '',
-                email: '',
-                phoneNumber: undefined,
-                activityStatus: {
-                    lastConnected: new Date(),
-                    birthday: new Date(),
-                },
-                birthDate: new Date(),
-                avatarUrl: undefined,
+                avatarUrl: '',
                 isPremium: false,
-                credit: undefined,
-                articles: undefined,
-                debit: undefined,
+                credit: 0,
+                balance: 0,
+                articles: [],
+                comments: [],
+                favoriteArticles: [],
             },
 
             setUserData: (userData: Partial<User>): void => {
@@ -42,9 +34,9 @@ export const useUserStore = create<UserStore>()(
                 })
             },
 
-            deleteStoredUserData: (): void => {
+            resetUserData: (): void => {
                 set((state) => {
-                    state.user = {} as User
+                    state.user = {} as Partial<User>
                 })
             },
         })),

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -8,6 +8,8 @@ type UserStore = {
     user: Partial<User>
     setUserData: (userData: Partial<User>) => void
     resetUserData: () => void
+    hasHydrated: boolean
+    setHasHydrated: (state: boolean) => void
 }
 
 /**
@@ -28,6 +30,11 @@ export const useUserStore = create<UserStore>()(
                 favoriteArticles: [],
             },
 
+            hasHydrated: false,
+            setHasHydrated: (state: boolean): void => {
+                set({ hasHydrated: state })
+            },
+
             setUserData: (userData: Partial<User>): void => {
                 set((state) => {
                     state.user = { ...state.user, ...userData }
@@ -42,6 +49,9 @@ export const useUserStore = create<UserStore>()(
         })),
         {
             name: 'user-store',
+            onRehydrateStorage: () => (state) => {
+                state?.setHasHydrated(true)
+            },
         },
     ),
 )

--- a/src/types/user/index.ts
+++ b/src/types/user/index.ts
@@ -4,11 +4,6 @@ import { z } from 'zod'
 
 import { AddressSchema } from '@/types/address/userAddress'
 
-const BankInfoSchema = z.object({
-    IBAN: z.string(),
-    BIC: z.string(),
-})
-
 export const ActivityStatusSchema = z.object({
     lastConnected: z.date(),
     birthday: z.date(),
@@ -16,7 +11,6 @@ export const ActivityStatusSchema = z.object({
 
 export const UserSchema = z.object({
     id: z.string(),
-    version: z.number().int(),
     pseudo: z.string(),
     name: z.string(),
     surname: z.string(),
@@ -26,14 +20,13 @@ export const UserSchema = z.object({
     phoneNumber: z.string().optional(),
     activityStatus: ActivityStatusSchema,
     birthDate: z.date(),
-    bankInfo: BankInfoSchema.optional(),
     avatarUrl: z.string().url().optional(),
     isPremium: z.boolean(),
     favoriteArticles: z.array(z.string()).optional(),
     credit: z.number().int().optional(),
+    balance: z.number().int().optional(),
     comments: z.array(z.string()).optional(),
     articles: z.array(z.string()).optional(),
-    debit: z.array(z.string()).optional(),
 })
 
 export type User = z.infer<typeof UserSchema>

--- a/src/utils/apiCalls/user/index.ts
+++ b/src/utils/apiCalls/user/index.ts
@@ -76,13 +76,17 @@ export const createUser = async (
  * @returns {Promise<User>|undefined} A promise that resolves with user information.
  */
 export const getUserById = async (
-    userId: string | undefined,
+    userId: string | undefined | null,
 ): Promise<User | undefined> => {
+    if (!userId) return undefined
+
     const response: AxiosResponse<User> = await userInstance.get(
         `${apiEndpoints.microServices.public.USERS}${userId}`,
     )
+
     if (response.status !== 200)
         throw new Error(`Failed to fetch user with id ${String(userId)}`)
+
     return response.data
 }
 

--- a/src/utils/apiCalls/user/index.ts
+++ b/src/utils/apiCalls/user/index.ts
@@ -79,7 +79,6 @@ export const getUserById = async (
     userId: string | undefined | null,
 ): Promise<User | undefined> => {
     if (!userId) return undefined
-    console.log('🚀 CALLED')
 
     const response: AxiosResponse<User> = await userInstance.get(
         `${apiEndpoints.microServices.public.USERS}${userId}`,

--- a/src/utils/apiCalls/user/index.ts
+++ b/src/utils/apiCalls/user/index.ts
@@ -79,6 +79,7 @@ export const getUserById = async (
     userId: string | undefined | null,
 ): Promise<User | undefined> => {
     if (!userId) return undefined
+    console.log('🚀 CALLED')
 
     const response: AxiosResponse<User> = await userInstance.get(
         `${apiEndpoints.microServices.public.USERS}${userId}`,

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -4,6 +4,7 @@ export const paginationLimit = 20
 /** The list of React Query keys  */
 export const rqKeys = {
     USERS: 'users',
+    USER: 'user',
 }
 
 /** Object containing page paths used throughout the application, set in alphabetical order */

--- a/src/utils/providers/UserStoreProvider.tsx
+++ b/src/utils/providers/UserStoreProvider.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import { useUserStore } from '@/stores/user'
+
+import { getUserById } from '../apiCalls/user'
+import { rqKeys } from '../constants'
+import { useAuth } from '@clerk/nextjs'
+import { useQuery } from '@tanstack/react-query'
+
+const UserStoreProvider = (): undefined => {
+    const { isLoaded, userId, isSignedIn } = useAuth()
+
+    const setUserData = useUserStore((state) => state.setUserData)
+    const resetUserData = useUserStore((state) => state.resetUserData)
+    const userStore = useUserStore((state) => state.user)
+
+    const { data: userQuery } = useQuery({
+        queryKey: [rqKeys.USER, userId],
+        queryFn: () => getUserById(userId),
+        enabled: !!userId,
+    })
+
+    useEffect(() => {
+        if (isLoaded && isSignedIn && userQuery && !userStore.pseudo) {
+            setUserData({
+                pseudo: userQuery.pseudo,
+                avatarUrl: userQuery.avatarUrl,
+                credit: userQuery.credit,
+                balance: userQuery.balance,
+                isPremium: userQuery.isPremium,
+            })
+        }
+
+        if (!isSignedIn && userStore.pseudo) resetUserData()
+    }, [
+        isLoaded,
+        isSignedIn,
+        userId,
+        setUserData,
+        userQuery,
+        userStore,
+        resetUserData,
+    ])
+
+    return undefined
+}
+
+export default UserStoreProvider

--- a/src/utils/providers/UserStoreProvider.tsx
+++ b/src/utils/providers/UserStoreProvider.tsx
@@ -15,11 +15,12 @@ const UserStoreProvider = (): undefined => {
     const setUserData = useUserStore((state) => state.setUserData)
     const resetUserData = useUserStore((state) => state.resetUserData)
     const userStore = useUserStore((state) => state.user)
+    const hasStoreHydrated = useUserStore((state) => state.hasHydrated)
 
     const { data: userQuery } = useQuery({
         queryKey: [rqKeys.USER, userId],
         queryFn: () => getUserById(userId),
-        enabled: !!userId,
+        enabled: !!userId && !userStore.pseudo && hasStoreHydrated,
     })
 
     useEffect(() => {


### PR DESCRIPTION
Modif sur ce ticket:
* Update sur le Schema du user
* Ajout d'un provider qui ajoute des données non-sensitive du user dans le store au moment du log in
* Au moment de la déconnexion, on reset le user store

Avantage du ticket est d'avoir des petites metadata du user, comme le pseudo, l'avatar, le isPremium boolean...à tout moment sans avoir à faire une requête au micro-service pour ça.
