### PR TITLE
🐛 Force a default value on credit and balance

### DIFF
--- a/src/utils/providers/UserStoreProvider.tsx
+++ b/src/utils/providers/UserStoreProvider.tsx
@@ -28,9 +28,9 @@ const UserStoreProvider = (): undefined => {
             setUserData({
                 pseudo: userQuery.pseudo,
                 avatarUrl: userQuery.avatarUrl,
-                credit: userQuery.credit,
-                balance: userQuery.balance,
-                isPremium: userQuery.isPremium,
+                credit: userQuery.credit || 0,
+                balance: userQuery.balance || 0,
+                isPremium: userQuery.isPremium || false,
             })
         }
 


### PR DESCRIPTION
Le back ne retournait pas la valeur de `credit` et `balance` si ces valeurs étaient à 0.